### PR TITLE
Provide SBT Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Chaos releases are available from Mesosphere's Maven repository.
 To add Chaos to a Maven project, add this to your `pom.xml`:
 
     <properties>
-        <chaos.version>0.4.5</chaos.version>
+        <chaos.version>0.5.2</chaos.version>
     </properties>
 
     ...
@@ -97,7 +97,7 @@ To add Chaos to an SBT project, add this to your `build.sbt`:
     resolvers += "Mesosphere Public Repo" at "http://downloads.mesosphere.io/maven"
     
     libraryDependencies ++= Seq(
-      "mesosphere" % "chaos" % "0.4.5",
+      "mesosphere" % "chaos" % "0.5.2",
       "com.sun.jersey" % "jersey-bundle" % "1.17.1"
     )
 


### PR DESCRIPTION
Having to add the jersey dependency is unfortunate. I'm not sure why that happened but it would be good to move that inside chaos somewhere.

Verified with extracted example buildable via maven and sbt.  https://github.com/kadwanev/chaos-example
