### PR TITLE
Bump version of jersey to 0.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <guava.version>14.0.1</guava.version>
         <guice.version>3.0</guice.version>
         <scallop.version>0.9.4</scallop.version>
-        <jersey.version>1.17.1</jersey.version>
+        <jersey.version>1.18.1</jersey.version>
         <metrics.version>3.0.0</metrics.version>
         <jetty.version>8.1.11.v20130520</jetty.version>
         <jackson.version>2.3.1</jackson.version>


### PR DESCRIPTION
Hi,

think I can't mvn release chaos.
A new version of chaos is needed for upstream libraries.

Cheers,
Matthias
