### PR TITLE
Fetch maven central dependencies from https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <pluginRepository>
             <id>repo1</id>
             <name>Maven Central</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Fetch maven central dependencies from https so that an attacker can't inject malicious code onto a developer's machine. See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/
