### PR TITLE
Implement auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ There is an example app in [src/main/scala/mesosphere/chaos/example]
 
     sbt run
 
+You can start the example with command line options as well:
+
+    sbt "run --shiro_ini file:./src/main/scala/mesosphere/chaos/example/shiro.ini"
+
 Make requests to the example endpoints with [HTTPie](https://github.com/jkbr/httpie):
 
     http localhost:8080/foo

--- a/project/build.scala
+++ b/project/build.scala
@@ -95,6 +95,12 @@ object Dependencies {
     metricsJetty % "compile",
     metricsServlets % "compile",
 
+    shiroJersey % "compile",
+    shiroWeb % "compile",
+    bujiPac4j % "compile",
+    pac4jHttp % "compile",
+    pac4jSaml % "compile",
+
     scallop % "compile",
     mustache % "compile",
     slf4jLog4j % "compile",
@@ -119,6 +125,10 @@ object Dependency {
     val Jetty = "8.1.15.v20140411"
     val Jackson = "2.4.1"
     val Hibernate = "5.1.2.Final"
+    val Shiro = "1.2.3"
+    val ShiroJersey = "0.1.0"
+    val BujiPac4j = "1.2.3"
+    val Pac4j = "1.6.0"
     val Mustache = "0.8.12"
     val Slf4j = "1.7.7"
 
@@ -146,6 +156,14 @@ object Dependency {
   val metricsJvm = "com.codahale.metrics" % "metrics-jvm" % V.Metrics
   val metricsJetty = "com.codahale.metrics" % "metrics-jetty8" % V.Metrics
   val metricsServlets = "com.codahale.metrics" % "metrics-servlets" % V.Metrics
+
+  val shiroJersey = "org.secnod.shiro" % "shiro-jersey" % V.ShiroJersey
+  val shiroWeb = "org.apache.shiro" % "shiro-web" % V.Shiro
+  val bujiPac4j = "io.buji" % "buji-pac4j" % V.BujiPac4j
+  val pac4jHttp = "org.pac4j" % "pac4j-http" % V.Pac4j
+  val pac4jSaml = "org.pac4j" % "pac4j-saml" % V.Pac4j excludeAll(
+    ExclusionRule(organization = "org.slf4j")
+  )
 
   val scallop = "org.rogach" %% "scallop" % V.Scallop
   val mustache = "com.github.spullara.mustache.java" % "compiler" % V.Mustache

--- a/src/main/scala/mesosphere/chaos/example/shiro.ini
+++ b/src/main/scala/mesosphere/chaos/example/shiro.ini
@@ -1,0 +1,5 @@
+[users]
+admin = password
+
+[urls]
+/** = noSessionCreation, authcBasic

--- a/src/main/scala/mesosphere/chaos/http/HttpConf.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpConf.scala
@@ -19,6 +19,10 @@ trait HttpConf extends ScallopConf {
   lazy val sslKeystorePassword = opt[String]("ssl_keystore_password",
     descr = "The password for the keystore", default = None, noshort = true)
 
+  lazy val shiroIni = opt[String]("shiro_ini",
+    descr = "The shiro.ini auth configuration file. See http://shiro.apache.org/",
+    default = None, noshort = true)
+
   lazy val httpCredentials = opt[String]("http_credentials",
     descr = "Credentials for accessing the http service. " +
       "If empty, anyone can access the HTTP endpoint. A username:password " +

--- a/src/main/scala/mesosphere/chaos/http/RestModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/RestModule.scala
@@ -1,18 +1,20 @@
 package mesosphere.chaos.http
 
+import javax.inject.Named
+import javax.validation.Validation
+import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
+
 import com.codahale.metrics.servlets.MetricsServlet
 import com.google.inject.{ Singleton, Provides, Scopes }
-import com.sun.jersey.guice.spi.container.servlet.GuiceContainer
+import com.google.inject.name.Names
+import com.google.inject.servlet.ServletModule
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import com.fasterxml.jackson.databind.{ Module, ObjectMapper }
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import javax.validation.Validation
-import com.google.inject.servlet.ServletModule
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer
 import mesosphere.chaos.validation.{ JacksonMessageBodyProvider, ConstraintViolationExceptionMapper }
-import javax.inject.Named
 import mesosphere.chaos.ServiceStatus
-import scala.collection.JavaConverters._
-import com.google.inject.name.Names
 
 /**
   * Base class for REST modules.
@@ -32,6 +34,10 @@ class RestModule extends ServletModule {
   // Override this if you want to add your own modules
   val jacksonModules: Iterable[Module] = Seq(DefaultScalaModule)
 
+  val params: java.util.Map[String, String] = Map(
+    "com.sun.jersey.spi.container.ResourceFilters" -> "org.secnod.shiro.jersey.ShiroResourceFilterFactory",
+    "javax.ws.rs.Application" -> "mesosphere.chaos.http.SecuredRestApplication")
+
   protected override def configureServlets() {
     bind(classOf[PingServlet]).in(Scopes.SINGLETON)
     bind(classOf[MetricsServlet]).in(Scopes.SINGLETON)
@@ -49,7 +55,7 @@ class RestModule extends ServletModule {
     serve(metricsUrl).`with`(classOf[MetricsServlet])
     serve(loggingUrl).`with`(classOf[LogConfigServlet])
     serve(helpUrl + "*").`with`(classOf[HelpServlet])
-    serve(guiceContainerUrl).`with`(classOf[GuiceContainer])
+    serve(guiceContainerUrl).`with`(classOf[GuiceContainer], params)
   }
 
   @Provides
@@ -66,5 +72,6 @@ class RestModule extends ServletModule {
     mapper.registerModules(jacksonModules.asJava)
     mapper
   }
+
 }
 

--- a/src/main/scala/mesosphere/chaos/http/SecuredRestApplication.scala
+++ b/src/main/scala/mesosphere/chaos/http/SecuredRestApplication.scala
@@ -1,0 +1,15 @@
+package mesosphere.chaos.http
+
+import scala.collection.JavaConversions._
+import javax.ws.rs.core.Application
+import org.secnod.shiro.jaxrs.ShiroExceptionMapper
+import org.secnod.shiro.jersey.SubjectInjectableProvider
+
+class SecuredRestApplication extends Application {
+
+  override def getSingletons(): java.util.Set[Object] = {
+    Set(
+      new SubjectInjectableProvider(),
+      new ShiroExceptionMapper())
+  }
+}


### PR DESCRIPTION
**Getting the Conversation Going**

I wanted to talk about how we might add support for additional authentication and authorization methods to Marathon. This is a change to a core part of the system and relies on some code that might be new to many folks here, so please don't hesitate to ask me for clarification about this proposal.

**What this Gives Us**

This pull request adds a framework for supporting additional authentication types (besides just basic authentication as we have now) and for supporting for authorization of resources. This means we'll be able to support people logging in via BasicAuth, DB, LDAP, OAuth, SAML, etc. We can also annotate resources as requiring a certain permission or role if we want some urls to be admin-only, read-only, unprotected, etc. And we can know who the logged in user is to log which user takes certain actions or to show who the logged in user is at the top of the webapp.

Many of the things I just mentioned will be important for attracting enterprise users of Marathon. We often have enterprise customers ask us to go through security reviews and things like MFA, logging of administrative actions, etc. are recurrent themes these reviews. Netflix, Dropbox, LinkedIn, and many other large tech companies use SAML (often via Identity Providers such as Okta and OneLogin) to handle MFA and SSO and it will be much easier to get customers like this when you fit in with their existing security infrastructure.

**Implementation**

I implemented this using Shiro. I chose Shiro because it gives us the ability to make this functionality very customizable. You can get pretty far just changing options in the shiro.ini. You could also drop in your own jar to further customize (though this already supports most authentication methods). The two main auth frameworks I could find were Shiro and Spring Auth. Spring Auth seemed extremely difficult to implement given that we're not using Spring Dependency Injection (Marathon and Chronos both use a bit of Guice). Shiro was a little tricky to figure out in a few places, but it has great support for a number of things we'd want to do like supporting multiple login methods out of the box and allowing us to use annotations like `@RequiresAuthentication` and `@RequiresPermissions`.

**Example**

I added to the example project a bit of code which reproduces the current Basic Auth behavior of http_credentials, but using Shiro instead so that it's also pluggable for other auth schemes.

**Next Steps**

Right now, the way that Marathon / Chronos / Chaos work is to send a basic auth header on every request (e.g. Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==). However, we need a solution that works with LDAP, SAML, etc. Thus, I suggest that we add a login callback which upon successful authentication creates a token, stores it in a cookie (to handle page reloads and futures visits), and then sends it to the server in a custom header (something like "Authorization: Chaos mytoken" or "X-AUTH: mytoken") with each request to the application's REST API. We could create some classes in Chaos to assist with this and an example of it. The auth token would have to be stored in a manner such that it could be accessed by multiple instances of the web server, so we'd probably want to store it in Zookeeper.
