### PR TITLE
Secure cmd line flags now settable via env variables

### DIFF
--- a/src/main/scala/mesosphere/chaos/http/HttpConf.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpConf.scala
@@ -40,6 +40,13 @@ trait HttpConf extends ScallopConf {
     noshort = true
   )
 
+  lazy val httpCredentialsRealm = opt[String](
+    "http_realm",
+    descr = "The security realm (aka 'area') associated with the credentials",
+    default = Option("Mesosphere"),
+    noshort = true
+  )
+
   lazy val assetsFileSystemPath = opt[String]("assets_path",
     descr = "Set a local file system path to load assets from, " +
       "instead of loading them from the packaged jar.",
@@ -51,13 +58,14 @@ trait HttpConf extends ScallopConf {
     case _                  => getClass.getClassLoader.getResource("assets")
   }
 
-  private lazy val httpCredentialsEnvName: String = "MESOSPHERE_HTTP_CREDENTIALS"
-  private lazy val httpCredentialsEnvValue: Option[String] = sys.env.get(httpCredentialsEnvName)
+  lazy val httpCredentialsEnvValue: Option[String] = sys.env.get(HttpConf.httpCredentialsEnvName)
+  lazy val sslKeystorePathEnvValue: Option[String] = sys.env.get(HttpConf.sslKeystorePathEnvName)
+  lazy val sslKeystorePasswordEnvValue: Option[String] = sys.env.get(HttpConf.sslKeystorePasswordEnvName)
 
-  private lazy val sslKeystorePathEnvName: String = "MESOSPHERE_KEYSTORE_PATH"
-  private lazy val sslKeystorePathEnvValue: Option[String] = sys.env.get(sslKeystorePathEnvName)
+}
 
-  private lazy val sslKeystorePasswordEnvName: String = "MESOSPHERE_KEYSTORE_PASS"
-  private lazy val sslKeystorePasswordEnvValue: Option[String] = sys.env.get(sslKeystorePasswordEnvName)
-
+object HttpConf {
+  val httpCredentialsEnvName: String = "MESOSPHERE_HTTP_CREDENTIALS"
+  val sslKeystorePathEnvName: String = "MESOSPHERE_KEYSTORE_PATH"
+  val sslKeystorePasswordEnvName: String = "MESOSPHERE_KEYSTORE_PASS"
 }

--- a/src/main/scala/mesosphere/chaos/http/HttpConf.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpConf.scala
@@ -17,18 +17,28 @@ trait HttpConf extends ScallopConf {
     descr = "The port to listen on for HTTPS requests", default = Some(8443),
     noshort = true)
 
-  lazy val sslKeystorePath = opt[String]("ssl_keystore_path",
+  lazy val sslKeystorePath = opt[String](
+    "ssl_keystore_path",
     descr = "Path to the keystore, if supplied, SSL is enabled",
-    default = None, noshort = true)
+    default = sslKeystorePathEnvValue,
+    noshort = true
+  )
 
-  lazy val sslKeystorePassword = opt[String]("ssl_keystore_password",
-    descr = "The password for the keystore", default = None, noshort = true)
+  lazy val sslKeystorePassword = opt[String](
+    "ssl_keystore_password",
+    descr = "The password for the keystore",
+    default = sslKeystorePasswordEnvValue,
+    noshort = true
+  )
 
-  lazy val httpCredentials = opt[String]("http_credentials",
+  lazy val httpCredentials = opt[String](
+    "http_credentials",
     descr = "Credentials for accessing the http service. " +
       "If empty, anyone can access the HTTP endpoint. A username:password " +
       "pair is expected where the username must not contain ':'",
-    default = None, noshort = true)
+    default = httpCredentialsEnvValue,
+    noshort = true
+  )
 
   lazy val assetsFileSystemPath = opt[String]("assets_path",
     descr = "Set a local file system path to load assets from, " +
@@ -40,4 +50,14 @@ trait HttpConf extends ScallopConf {
     // Default to the asset path in the jar
     case _                  => getClass.getClassLoader.getResource("assets")
   }
+
+  private lazy val httpCredentialsEnvName: String = "MESOSPHERE_HTTP_CREDENTIALS"
+  private lazy val httpCredentialsEnvValue: Option[String] = sys.env.get(httpCredentialsEnvName)
+
+  private lazy val sslKeystorePathEnvName: String = "MESOSPHERE_KEYSTORE_PATH"
+  private lazy val sslKeystorePathEnvValue: Option[String] = sys.env.get(sslKeystorePathEnvName)
+
+  private lazy val sslKeystorePasswordEnvName: String = "MESOSPHERE_KEYSTORE_PASS"
+  private lazy val sslKeystorePasswordEnvValue: Option[String] = sys.env.get(sslKeystorePasswordEnvName)
+
 }

--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -16,8 +16,6 @@ import org.eclipse.jetty.server.handler.{ RequestLogHandler, HandlerCollection }
 import org.eclipse.jetty.servlet.{ DefaultServlet, ServletContextHandler }
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.security.{ Password, Constraint }
-import scala.Array
-import scala.Some
 import org.eclipse.jetty.server.ssl.SslSelectChannelConnector
 
 class HttpModule(conf: HttpConf) extends AbstractModule {
@@ -25,6 +23,8 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
   // TODO make configurable
   val welcomeFiles = Array("index.html")
   private[this] val log = Logger.getLogger(getClass.getName)
+
+  private val REALM = "Mesosphere"
 
   protected val resourceCacheControlHeader: Option[String] = None
 
@@ -35,18 +35,26 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
   }
 
   def getSSLConnector(server: Server): Option[Connector] = {
-    if (conf.sslKeystorePath.isSupplied) {
-      val keystore = new File(conf.sslKeystorePath())
-      require(keystore.exists() && keystore.canRead,
-        f"${conf.sslKeystorePath()} is invalid or not readable!")
-      val contextFactory = new SslContextFactory()
-      contextFactory.setKeyStorePath(conf.sslKeystorePath())
-      contextFactory.setKeyStorePassword(conf.sslKeystorePassword())
-      val sslConnector = new SslSelectChannelConnector(contextFactory)
-      sslConnector.setPort(conf.httpsPort())
-      return Some(sslConnector)
-    }
-    None
+    for {
+      keystorePath <- conf.sslKeystorePath.get
+      keystorePassword <- conf.sslKeystorePassword.get
+      connector = createSSLConnector(keystorePath, keystorePassword)
+    } yield connector
+  }
+
+  def createSSLConnector(keystorePath: String, keystorePassword: String): SslSelectChannelConnector = {
+    val keystore = new File(keystorePath)
+    require(keystore.exists() && keystore.canRead,
+      f"${conf.sslKeystorePath()} is invalid or not readable!")
+
+    val contextFactory = new SslContextFactory()
+    contextFactory.setKeyStorePath(keystorePath)
+    contextFactory.setKeyStorePassword(keystorePassword)
+
+    val sslConnector = new SslSelectChannelConnector(contextFactory)
+    sslConnector.setPort(conf.httpsPort())
+
+    sslConnector
   }
 
   @Provides
@@ -110,13 +118,28 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
     handler.addServlet(classOf[DefaultServlet], "/*")
     handler.addFilter(classOf[GuiceFilter], "/*", util.EnumSet.allOf(classOf[DispatcherType]))
     handler.addEventListener(guiceServletConf)
-    if (conf.httpCredentials.isSupplied) {
-      handler.setSecurityHandler(getSecurityHandler())
-    }
+
+    conf.httpCredentials.get flatMap createSecurityHandler foreach handler.setSecurityHandler
     handler
   }
+  
 
-  def getSecurityHandler(): ConstraintSecurityHandler = {
+  def createSecurityHandler(httpCredentials: String): Option[ConstraintSecurityHandler] = {
+
+    val credentialsPattern = "(.+):(.+)".r
+
+    httpCredentials match {
+      case credentialsPattern(userName, password) =>
+        Option(createSecurityHandler(userName, password))
+      case _ =>
+        log.error(s"The HTTP credentials must be specified in the form of 'user:password'.")
+        None
+    }
+  }
+  
+
+  def createSecurityHandler(userName: String, password: String): ConstraintSecurityHandler = {
+
     val constraint = new Constraint(Constraint.__BASIC_AUTH, "user")
     constraint.setAuthenticate(true)
 
@@ -132,32 +155,26 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
     // and assign the realm.
     val csh = new ConstraintSecurityHandler()
     csh.setAuthenticator(new BasicAuthenticator())
-    csh.setRealmName("chaos-realm")
-    csh.addConstraintMapping(cm);
+    csh.setRealmName(REALM)
+    csh.addConstraintMapping(cm)
+    csh.setLoginService(createLoginService(userName, password))
 
-    val loginService = new KeyValueLoginService
-    require(conf.httpCredentials().contains(":"),
-      f"http_credentials '${conf.httpCredentials()}' " +
-        f"must contain a ':' to separate user and password.")
-    val tup = conf.httpCredentials().split(":", 2)
-
-    //TODO(*): Use a MD5 instead.
-    loginService.putUser(tup(0), new Password(tup(1)), Array("user"))
-
-    csh.setLoginService(loginService)
     csh
   }
-}
+  
 
-//TODO(*): Allow alternative loading from file.
-class KeyValueLoginService()
-    extends MappedLoginService {
+  def createLoginService(userName: String, password: String): LoginService = {
 
-  def loadUser(username: String): UserIdentity = {
-    return null
+    val loginService = new MappedLoginService() {
+      override def loadUser(username: String): UserIdentity = null
+      override def loadUsers(): Unit = {}
+      override def getName: String = REALM
+    }
+
+    //TODO(*): Use a MD5 instead.
+    loginService.putUser(userName, new Password(password), Array("user"))
+    loginService
   }
 
-  def loadUsers {
-  }
-
 }
+

--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -24,8 +24,6 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
   val welcomeFiles = Array("index.html")
   private[this] val log = Logger.getLogger(getClass.getName)
 
-  private val REALM = "Mesosphere"
-
   protected val resourceCacheControlHeader: Option[String] = None
 
   def configure() {
@@ -122,7 +120,6 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
     conf.httpCredentials.get flatMap createSecurityHandler foreach handler.setSecurityHandler
     handler
   }
-  
 
   def createSecurityHandler(httpCredentials: String): Option[ConstraintSecurityHandler] = {
 
@@ -136,7 +133,6 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
         None
     }
   }
-  
 
   def createSecurityHandler(userName: String, password: String): ConstraintSecurityHandler = {
 
@@ -155,20 +151,19 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
     // and assign the realm.
     val csh = new ConstraintSecurityHandler()
     csh.setAuthenticator(new BasicAuthenticator())
-    csh.setRealmName(REALM)
+    csh.setRealmName(conf.httpCredentialsRealm())
     csh.addConstraintMapping(cm)
     csh.setLoginService(createLoginService(userName, password))
 
     csh
   }
-  
 
   def createLoginService(userName: String, password: String): LoginService = {
 
     val loginService = new MappedLoginService() {
       override def loadUser(username: String): UserIdentity = null
       override def loadUsers(): Unit = {}
-      override def getName: String = REALM
+      override def getName: String = conf.httpCredentialsRealm()
     }
 
     //TODO(*): Use a MD5 instead.


### PR DESCRIPTION
Fixes #25 (realm not set), #26 (don't log invalid credentials) and #27 (secure cmd line flags settable via env variables). Would like to get this published and then picked up by Marathon and Chronos which really need these core fixes.


