### PR TITLE
Fixes #14 - Allow disabling HTTP when HTTPS is used

### DIFF
--- a/src/main/scala/mesosphere/chaos/http/HttpConf.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpConf.scala
@@ -5,12 +5,21 @@ import java.net.URL
 
 trait HttpConf extends ScallopConf {
 
+  lazy val disableHttp = opt[Boolean]("disable_http",
+    descr = "Disable listening for HTTP requests completely. HTTPS is unaffected.",
+    noshort = true,
+    default = Some(false))
+
   lazy val httpAddress = opt[String]("http_address",
     descr = "The address to listen on for HTTP requests", default = None,
     noshort = true)
 
   lazy val httpPort = opt[Int]("http_port",
     descr = "The port to listen on for HTTP requests", default = Some(8080),
+    noshort = true)
+
+  lazy val httpsAddress = opt[String]("https_address",
+    descr = "The address to listen on for HTTPS requests.", default = None,
     noshort = true)
 
   lazy val httpsPort = opt[Int]("https_port",


### PR DESCRIPTION
Introduces a new command line option --http_disable to completely
disable the HTTP connector. It is not done automatically if SSL
is enabled to preserve backward compatibility. Instead, a warning
will be logged if SSL for HTTPS is used but HTTP is still enabled.

If neither HTTP or HTTPS are enabled, an exception is thrown.