### PR TITLE
Propagate exceptions during HttpService start.

### DIFF
--- a/src/main/scala/mesosphere/chaos/http/HttpService.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpService.scala
@@ -15,13 +15,15 @@ class HttpService @Inject() (val server: Server) extends AbstractIdleService {
 
   def startUp() {
     log.debug("Starting up HttpServer.")
-    Try(
-      server.start()).recoverWith {
-        case e: java.net.BindException => {
-          log.fatal("Failed to start HTTP service", e)
-          Try(server.stop())
-        }
-      }
+    try {
+      server.start()
+    }
+    catch {
+      case e: Exception =>
+        log.fatal("Failed to start HTTP service", e)
+        Try(server.stop())
+        throw e
+    }
   }
 
   def shutDown() {


### PR DESCRIPTION
Propagate exceptions (e.g. BindException) thrown during startup of the service.

HttpService inherits from AbstractIdleService, whose implementation of the
startAsync method which will catch these exceptions and mark the service as
failed.

This commit is needed in order to fix Marathon's issue #1818: Marathon should fail during start, if the HTTP port is already bound 
