### PR TITLE
Remove the line number in logging statements (it is very expensive) 

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%t)%n


### PR DESCRIPTION
and replace with calling thread.

Quote from the [javadoc](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html):
> WARNING Generating caller location information is extremely slow and should be avoided unless execution speed is not an issue.