### PR TITLE
Add optional gzip compression (enabled per default)

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -122,15 +122,15 @@ object Dependency {
     // runtime deps versions
     val Guava = "17.0"
     val Guice = "3.0"
-    val Scallop = "0.9.5"
+    val Scallop = "1.0.0"
     val Jersey = "1.18.1"
     val Metrics = "3.1.2"
     val Jetty = "9.3.6.v20151106"
     val Jackson = "2.6.1"
     val Hibernate = "5.2.1.Final"
     val Mustache = "0.9.0"
-    val Logback = "1.1.3"
-    val Slf4j = "1.7.12"
+    val Logback = "1.1.7"
+    val Slf4j = "1.7.21"
     val LiftMarkdown = "2.6.2"
     val Glassfish = "2.2.6"
 

--- a/src/main/scala/mesosphere/chaos/App.scala
+++ b/src/main/scala/mesosphere/chaos/App.scala
@@ -21,13 +21,7 @@ trait App extends scala.App {
 
   def modules(): Iterable[_ <: Module]
 
-  def initConf() {
-    conf().afterInit()
-  }
-
   def run(classes: Class[_ <: Service]*) {
-    initConf()
-
     val services = classes.map(injector.getInstance(_))
     val serviceManager = new ServiceManager(services.asJava)
     this.serviceManager = Some(serviceManager)

--- a/src/main/scala/mesosphere/chaos/http/HttpConf.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpConf.scala
@@ -61,16 +61,19 @@ trait HttpConf extends ScallopConf {
     noshort = true
   )
 
+  lazy val httpCompression = toggle("http_compression",
+    default = Some(true),
+    noshort = true,
+    descrYes = "(Default) Enable http compression.",
+    descrNo = "Disable http compression. ",
+    prefix = "disable_"
+  )
+
+  @deprecated("Asset path is not supported.", since = "0.8.5")
   lazy val assetsFileSystemPath = opt[String]("assets_path",
     descr = "Set a local file system path to load assets from, " +
       "instead of loading them from the packaged jar.",
-    default = None, noshort = true)
-
-  def assetsUrl(): URL = assetsFileSystemPath.get match {
-    case Some(path: String) => new URL(s"file:$path")
-    // Default to the asset path in the jar
-    case _                  => getClass.getClassLoader.getResource("assets")
-  }
+    default = None, noshort = true, hidden = true)
 
   lazy val httpCredentialsEnvValue: Option[String] = sys.env.get(HttpConf.httpCredentialsEnvName)
   lazy val sslKeystorePathEnvValue: Option[String] = sys.env.get(HttpConf.sslKeystorePathEnvName)


### PR DESCRIPTION
-Bump Scallop to latest stable (without delayed init)
-Deprecate assetsUrl (does not work correctly)