### PR TITLE
FIxes #64 - wires Rest, Http, Metric modules through MacWire.

### DIFF
--- a/chaos-examples/src/main/scala/mesosphere/chaos/examples/Main.scala
+++ b/chaos-examples/src/main/scala/mesosphere/chaos/examples/Main.scala
@@ -14,5 +14,5 @@ object Main extends App {
   // Derives from RestModule adding some example resources to it.
   val exampleModule = new PersonsModule(chaosModule)
 
-  run(chaosModule.httpModule.httpService)
+  run(exampleModule.httpService)
 }

--- a/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
+++ b/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
@@ -3,7 +3,11 @@ package mesosphere.chaos.examples.persons
 import mesosphere.chaos.ChaosModule
 import mesosphere.chaos.examples.persons.impl.PersonsResource
 import mesosphere.chaos.rest.RestModule
+import com.softwaremill.macwire._
 
 class PersonsModule(chaosModule: ChaosModule) extends RestModule(chaosModule) {
-  httpService.registerResources(new PersonsResource(Seq("Alice", "Bob", "Christoph", "Dimitri")))
+  lazy val persons = Seq("Alice", "Bob", "Christoph", "Dimitri")
+  lazy val personsResource = wire[PersonsResource]
+
+  httpService.registerResources(personsResource)
 }

--- a/src/main/scala/mesosphere/chaos/ChaosModule.scala
+++ b/src/main/scala/mesosphere/chaos/ChaosModule.scala
@@ -2,12 +2,16 @@ package mesosphere.chaos
 
 import mesosphere.chaos.http.{ HttpConf, HttpModule }
 import mesosphere.chaos.metrics.MetricsModule
+import com.softwaremill.macwire._
 
 /**
   * Wraps up the metrics and http modules.
   * @param conf configuration used to set up the http server.
   */
+@Module
 class ChaosModule(conf: HttpConf) {
-  lazy val metricsModule = new MetricsModule
-  lazy val httpModule = new HttpModule(conf, metricsModule.registry)
+  lazy val httpModule = wire[HttpModule]
+  lazy val metricsModule = wire[MetricsModule]
+  // Needed for http module.
+  lazy val metricsRegistry = metricsModule.registry
 }

--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -2,13 +2,14 @@ package mesosphere.chaos.http
 
 import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.impl.{ HttpServer, HttpServiceImpl }
+import com.softwaremill.macwire._
 
 /**
   * Provides a http service, which in it's turn contains a Jetty http server.
-  * @param conf configuration needed in order to set up the Jetty server.
-  * @param registry a metric registry.
+  * @param httpConf configuration needed in order to set up the Jetty server.
   */
-class HttpModule(conf: HttpConf,
-                 registry: MetricRegistry) {
-  lazy val httpService: HttpService = new HttpServiceImpl(new HttpServer(conf, registry))
+@Module
+class HttpModule(httpConf: HttpConf, metricsRegistry: MetricRegistry) {
+  lazy val httpServer = wire[HttpServer]
+  lazy val httpService = wire[HttpServiceImpl]
 }

--- a/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
@@ -1,10 +1,10 @@
 package mesosphere.chaos.metrics
 
-import java.lang.management.ManagementFactory
-
-import com.codahale.metrics.MetricRegistry
-import com.codahale.metrics.jvm.{ BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet, ThreadStatesGaugeSet }
+import com.codahale.metrics.jvm._
+import mesosphere.chaos.metrics.impl.{ DefaultBufferPoolMetricSet, DefaultMetricRegistry }
 import org.slf4j.LoggerFactory
+
+import com.softwaremill.macwire._
 
 /**
   * Includes a registry of metric instances. Those contain:
@@ -14,14 +14,13 @@ import org.slf4j.LoggerFactory
   *    GC-specific memory pools.
   *  - a set of gauges for the number of threads in their various states and deadlock detection.
   */
+@Module
 class MetricsModule {
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
-  lazy val registry: MetricRegistry = {
-    val registry = new MetricRegistry
-    registry.register("jvm.gc", new GarbageCollectorMetricSet())
-    registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer))
-    registry.register("jvm.memory", new MemoryUsageGaugeSet())
-    registry.register("jvm.threads", new ThreadStatesGaugeSet())
-    registry
-  }
+
+  lazy val garbageCollector = wire[GarbageCollectorMetricSet]
+  lazy val threadState = wire[ThreadStatesGaugeSet]
+  lazy val memoryUsage = wire[MemoryUsageGaugeSet]
+  lazy val bufferPool = wire[DefaultBufferPoolMetricSet]
+  lazy val registry = wire[DefaultMetricRegistry]
 }

--- a/src/main/scala/mesosphere/chaos/metrics/impl/DefaultBufferPoolMetricSet.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/impl/DefaultBufferPoolMetricSet.scala
@@ -1,0 +1,6 @@
+package mesosphere.chaos.metrics.impl
+
+import java.lang.management.ManagementFactory
+import com.codahale.metrics.jvm.BufferPoolMetricSet
+
+class DefaultBufferPoolMetricSet extends BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer)

--- a/src/main/scala/mesosphere/chaos/metrics/impl/DefaultMetricRegistry.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/impl/DefaultMetricRegistry.scala
@@ -1,0 +1,17 @@
+package mesosphere.chaos.metrics.impl
+
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet
+import com.codahale.metrics.jvm.BufferPoolMetricSet
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet
+
+class DefaultMetricRegistry(garbageCollectorMetricSet: GarbageCollectorMetricSet,
+                            bufferPoolMetricSet: BufferPoolMetricSet,
+                            memoryUsageGaugeSet: MemoryUsageGaugeSet,
+                            threadStatesGaugeSet: ThreadStatesGaugeSet) extends MetricRegistry {
+  register("jvm.gc", garbageCollectorMetricSet)
+  register("jvm.buffers", bufferPoolMetricSet)
+  register("jvm.memory", memoryUsageGaugeSet)
+  register("jvm.threads", threadStatesGaugeSet)
+}

--- a/src/main/scala/mesosphere/chaos/rest/RestModule.scala
+++ b/src/main/scala/mesosphere/chaos/rest/RestModule.scala
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpServlet
 import com.codahale.metrics.servlets.MetricsServlet
 import mesosphere.chaos.ChaosModule
 import mesosphere.chaos.rest.impl.{ LogConfigServlet, PingServlet }
+import com.softwaremill.macwire._
 
 /**
   * Registers a couple of default servlets to the Jetty server. Those are:
@@ -13,6 +14,7 @@ import mesosphere.chaos.rest.impl.{ LogConfigServlet, PingServlet }
   *  - logging servlet. Allows dynamic adjustments of http configuration.
   * @param chaosModule module including the metrics and http modules.
   */
+@Module
 class RestModule(chaosModule: ChaosModule) {
   // Override these in a subclass to mount resources at a different path
   val pingUrl = "/ping"
@@ -20,9 +22,10 @@ class RestModule(chaosModule: ChaosModule) {
   val loggingUrl = "/logging"
 
   // Initializing servlets
-  lazy val pingServlet: HttpServlet = new PingServlet
-  lazy val metricsServlet: HttpServlet = new MetricsServlet(chaosModule.metricsModule.registry)
-  lazy val logConfigServlet: HttpServlet = new LogConfigServlet
+  lazy val pingServlet: HttpServlet = wire[PingServlet]
+  lazy val registry = chaosModule.metricsModule.registry
+  lazy val metricsServlet: HttpServlet = new MetricsServlet(registry)
+  lazy val logConfigServlet: HttpServlet = wire[LogConfigServlet]
 
   // Binding servlets
   val httpService = chaosModule.httpModule.httpService


### PR DESCRIPTION
@aquamatthias I did it the classical way, meaning with classes and arguments, instead of traits. I also have the cake pattern trait version. I would upload it in a separate branch, so we could compare it directly. I am still leaning towards cake, but that is just a personal matter.
