### PR TITLE
Fixes #64 - wires Rest, Http, Metric modules through MacWire. Cake Pattern version with traits.

### DIFF
--- a/chaos-examples/src/main/scala/mesosphere/chaos/examples/Main.scala
+++ b/chaos-examples/src/main/scala/mesosphere/chaos/examples/Main.scala
@@ -1,7 +1,7 @@
 package mesosphere.chaos.examples
 
 import mesosphere.chaos.http.HttpConf
-import mesosphere.chaos.{ AppConfiguration, ChaosModule, App }
+import mesosphere.chaos.{ AppConfiguration, App }
 import mesosphere.chaos.examples.persons.PersonsModule
 import org.rogach.scallop.ScallopConf
 
@@ -9,10 +9,8 @@ object Main extends App {
   lazy val conf = new ScallopConf(args) with HttpConf with AppConfiguration
   conf.afterInit()
 
-  // Creating chaos module, which contains ScallopConf, MetricsModule and HttpModule.
-  val chaosModule = new ChaosModule(conf)
-  // Derives from RestModule adding some example resources to it.
-  val exampleModule = new PersonsModule(chaosModule)
+  // Creating persons module, which contains ScallopConf, MetricsModule and HttpModule.
+  val personsModule = new PersonsModule { def httpConf = conf }
 
-  run(chaosModule.httpModule.httpService)
+  run(personsModule.httpService)
 }

--- a/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
+++ b/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
@@ -1,11 +1,11 @@
 package mesosphere.chaos.examples.persons
 
-import mesosphere.chaos.ChaosModule
 import mesosphere.chaos.examples.persons.impl.PersonsResource
 import mesosphere.chaos.rest.RestModule
 import com.softwaremill.macwire._
 
-class PersonsModule(chaosModule: ChaosModule) extends RestModule(chaosModule) {
+@Module
+trait PersonsModule extends RestModule {
   lazy val persons = Seq("Alice", "Bob", "Christoph", "Dimitri")
   lazy val personsResource = wire[PersonsResource]
 

--- a/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
+++ b/chaos-examples/src/main/scala/mesosphere/chaos/examples/persons/PersonsModule.scala
@@ -3,7 +3,11 @@ package mesosphere.chaos.examples.persons
 import mesosphere.chaos.ChaosModule
 import mesosphere.chaos.examples.persons.impl.PersonsResource
 import mesosphere.chaos.rest.RestModule
+import com.softwaremill.macwire._
 
 class PersonsModule(chaosModule: ChaosModule) extends RestModule(chaosModule) {
-  httpService.registerResources(new PersonsResource(Seq("Alice", "Bob", "Christoph", "Dimitri")))
+  lazy val persons = Seq("Alice", "Bob", "Christoph", "Dimitri")
+  lazy val personsResource = wire[PersonsResource]
+
+  httpService.registerResources(personsResource)
 }

--- a/src/main/scala/mesosphere/chaos/ChaosModule.scala
+++ b/src/main/scala/mesosphere/chaos/ChaosModule.scala
@@ -2,12 +2,16 @@ package mesosphere.chaos
 
 import mesosphere.chaos.http.{ HttpConf, HttpModule }
 import mesosphere.chaos.metrics.MetricsModule
+import com.softwaremill.macwire._
 
 /**
   * Wraps up the metrics and http modules.
   * @param conf configuration used to set up the http server.
   */
+@Module
 class ChaosModule(conf: HttpConf) {
-  lazy val metricsModule = new MetricsModule
-  lazy val httpModule = new HttpModule(conf, metricsModule.registry)
+  lazy val httpModule = wire[HttpModule]
+  lazy val metricsModule = wire[MetricsModule]
+  // Needed for http module.
+  lazy val metricsRegistry = metricsModule.registry
 }

--- a/src/main/scala/mesosphere/chaos/ChaosModule.scala
+++ b/src/main/scala/mesosphere/chaos/ChaosModule.scala
@@ -1,17 +1,11 @@
 package mesosphere.chaos
 
-import mesosphere.chaos.http.{ HttpConf, HttpModule }
+import com.softwaremill.macwire.Module
+import mesosphere.chaos.http.HttpModule
 import mesosphere.chaos.metrics.MetricsModule
-import com.softwaremill.macwire._
 
 /**
   * Wraps up the metrics and http modules.
-  * @param conf configuration used to set up the http server.
   */
 @Module
-class ChaosModule(conf: HttpConf) {
-  lazy val httpModule = wire[HttpModule]
-  lazy val metricsModule = wire[MetricsModule]
-  // Needed for http module.
-  lazy val metricsRegistry = metricsModule.registry
-}
+trait ChaosModule extends MetricsModule with HttpModule

--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -2,13 +2,14 @@ package mesosphere.chaos.http
 
 import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.impl.{ HttpServer, HttpServiceImpl }
+import com.softwaremill.macwire._
 
 /**
   * Provides a http service, which in it's turn contains a Jetty http server.
-  * @param conf configuration needed in order to set up the Jetty server.
-  * @param registry a metric registry.
+  * @param httpConf configuration needed in order to set up the Jetty server.
   */
-class HttpModule(conf: HttpConf,
-                 registry: MetricRegistry) {
-  lazy val httpService: HttpService = new HttpServiceImpl(new HttpServer(conf, registry))
+@Module
+class HttpModule(httpConf: HttpConf, metricsRegistry: MetricRegistry) {
+  lazy val httpServer = wire[HttpServer]
+  lazy val httpService = wire[HttpServiceImpl]
 }

--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -1,15 +1,17 @@
 package mesosphere.chaos.http
 
-import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.impl.{ HttpServer, HttpServiceImpl }
 import com.softwaremill.macwire._
+import mesosphere.chaos.metrics.MetricsModule
 
 /**
   * Provides a http service, which in it's turn contains a Jetty http server.
-  * @param httpConf configuration needed in order to set up the Jetty server.
   */
 @Module
-class HttpModule(httpConf: HttpConf, metricsRegistry: MetricRegistry) {
+trait HttpModule extends MetricsModule {
+  // dependency: configuration needed in order to set up the Jetty server.
+  def httpConf: HttpConf
+
   lazy val httpServer = wire[HttpServer]
   lazy val httpService = wire[HttpServiceImpl]
 }

--- a/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
@@ -15,7 +15,7 @@ import com.softwaremill.macwire._
   *  - a set of gauges for the number of threads in their various states and deadlock detection.
   */
 @Module
-class MetricsModule {
+trait MetricsModule {
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   lazy val garbageCollector = wire[GarbageCollectorMetricSet]

--- a/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/MetricsModule.scala
@@ -1,10 +1,10 @@
 package mesosphere.chaos.metrics
 
-import java.lang.management.ManagementFactory
-
-import com.codahale.metrics.MetricRegistry
-import com.codahale.metrics.jvm.{ BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet, ThreadStatesGaugeSet }
+import com.codahale.metrics.jvm._
+import mesosphere.chaos.metrics.impl.{ DefaultBufferPoolMetricSet, DefaultMetricRegistry }
 import org.slf4j.LoggerFactory
+
+import com.softwaremill.macwire._
 
 /**
   * Includes a registry of metric instances. Those contain:
@@ -14,14 +14,13 @@ import org.slf4j.LoggerFactory
   *    GC-specific memory pools.
   *  - a set of gauges for the number of threads in their various states and deadlock detection.
   */
+@Module
 class MetricsModule {
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
-  lazy val registry: MetricRegistry = {
-    val registry = new MetricRegistry
-    registry.register("jvm.gc", new GarbageCollectorMetricSet())
-    registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer))
-    registry.register("jvm.memory", new MemoryUsageGaugeSet())
-    registry.register("jvm.threads", new ThreadStatesGaugeSet())
-    registry
-  }
+
+  lazy val garbageCollector = wire[GarbageCollectorMetricSet]
+  lazy val threadState = wire[ThreadStatesGaugeSet]
+  lazy val memoryUsage = wire[MemoryUsageGaugeSet]
+  lazy val bufferPool = wire[DefaultBufferPoolMetricSet]
+  lazy val registry = wire[DefaultMetricRegistry]
 }

--- a/src/main/scala/mesosphere/chaos/metrics/impl/DefaultBufferPoolMetricSet.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/impl/DefaultBufferPoolMetricSet.scala
@@ -1,0 +1,6 @@
+package mesosphere.chaos.metrics.impl
+
+import java.lang.management.ManagementFactory
+import com.codahale.metrics.jvm.BufferPoolMetricSet
+
+class DefaultBufferPoolMetricSet extends BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer)

--- a/src/main/scala/mesosphere/chaos/metrics/impl/DefaultMetricRegistry.scala
+++ b/src/main/scala/mesosphere/chaos/metrics/impl/DefaultMetricRegistry.scala
@@ -1,0 +1,17 @@
+package mesosphere.chaos.metrics.impl
+
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet
+import com.codahale.metrics.jvm.BufferPoolMetricSet
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet
+
+class DefaultMetricRegistry(garbageCollectorMetricSet: GarbageCollectorMetricSet,
+                            bufferPoolMetricSet: BufferPoolMetricSet,
+                            memoryUsageGaugeSet: MemoryUsageGaugeSet,
+                            threadStatesGaugeSet: ThreadStatesGaugeSet) extends MetricRegistry {
+  register("jvm.gc", garbageCollectorMetricSet)
+  register("jvm.buffers", bufferPoolMetricSet)
+  register("jvm.memory", memoryUsageGaugeSet)
+  register("jvm.threads", threadStatesGaugeSet)
+}

--- a/src/main/scala/mesosphere/chaos/rest/RestModule.scala
+++ b/src/main/scala/mesosphere/chaos/rest/RestModule.scala
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpServlet
 import com.codahale.metrics.servlets.MetricsServlet
 import mesosphere.chaos.ChaosModule
 import mesosphere.chaos.rest.impl.{ LogConfigServlet, PingServlet }
+import com.softwaremill.macwire._
 
 /**
   * Registers a couple of default servlets to the Jetty server. Those are:
@@ -13,6 +14,7 @@ import mesosphere.chaos.rest.impl.{ LogConfigServlet, PingServlet }
   *  - logging servlet. Allows dynamic adjustments of http configuration.
   * @param chaosModule module including the metrics and http modules.
   */
+@Module
 class RestModule(chaosModule: ChaosModule) {
   // Override these in a subclass to mount resources at a different path
   val pingUrl = "/ping"
@@ -20,9 +22,10 @@ class RestModule(chaosModule: ChaosModule) {
   val loggingUrl = "/logging"
 
   // Initializing servlets
-  lazy val pingServlet: HttpServlet = new PingServlet
-  lazy val metricsServlet: HttpServlet = new MetricsServlet(chaosModule.metricsModule.registry)
-  lazy val logConfigServlet: HttpServlet = new LogConfigServlet
+  lazy val pingServlet: HttpServlet = wire[PingServlet]
+  lazy val registry = chaosModule.metricsModule.registry
+  lazy val metricsServlet: HttpServlet = new MetricsServlet(registry)
+  lazy val logConfigServlet: HttpServlet = wire[LogConfigServlet]
 
   // Binding servlets
   val httpService = chaosModule.httpModule.httpService

--- a/src/main/scala/mesosphere/chaos/rest/RestModule.scala
+++ b/src/main/scala/mesosphere/chaos/rest/RestModule.scala
@@ -3,7 +3,8 @@ package mesosphere.chaos.rest
 import javax.servlet.http.HttpServlet
 
 import com.codahale.metrics.servlets.MetricsServlet
-import mesosphere.chaos.ChaosModule
+import mesosphere.chaos.http.HttpModule
+import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.chaos.rest.impl.{ LogConfigServlet, PingServlet }
 import com.softwaremill.macwire._
 
@@ -12,10 +13,9 @@ import com.softwaremill.macwire._
   *  - ping servlet. Replies to a GET by printing "pong".
   *  - metrics servlet. Lists all metrics included in the metrics registry.
   *  - logging servlet. Allows dynamic adjustments of http configuration.
-  * @param chaosModule module including the metrics and http modules.
   */
 @Module
-class RestModule(chaosModule: ChaosModule) {
+trait RestModule extends HttpModule with MetricsModule {
   // Override these in a subclass to mount resources at a different path
   val pingUrl = "/ping"
   val metricsUrl = "/metrics"
@@ -23,12 +23,11 @@ class RestModule(chaosModule: ChaosModule) {
 
   // Initializing servlets
   lazy val pingServlet: HttpServlet = wire[PingServlet]
-  lazy val registry = chaosModule.metricsModule.registry
+  // Needs to be explicit, due to main constructor taking no registry.
   lazy val metricsServlet: HttpServlet = new MetricsServlet(registry)
   lazy val logConfigServlet: HttpServlet = wire[LogConfigServlet]
 
   // Binding servlets
-  val httpService = chaosModule.httpModule.httpService
   httpService.registerServlet(pingServlet, pingUrl)
   httpService.registerServlet(metricsServlet, metricsUrl)
   httpService.registerServlet(logConfigServlet, loggingUrl)


### PR DESCRIPTION
@aquamatthias @gkleiman @meichstedt here is the cake pattern version with modules as traits.

I kind of dig it, but am open to both versions. Stating dependencies explicitly through class arguments has its advantage in terms of readability. But I like the way you can mix in the modules as a one-liner via traits (see [ChaosModule.scala](https://github.com/mesosphere/chaos/compare/aw/%2364-modules-to-macwire...aw/%2364-cake-pattern-trait-version?expand=1#diff-505de8927a52a043fca449f5063f3b26R11))

What do you guys think?
