### PR TITLE
Do not send the Server header in any Http response.

### DIFF
--- a/src/main/scala/mesosphere/chaos/http/HttpModule.scala
+++ b/src/main/scala/mesosphere/chaos/http/HttpModule.scala
@@ -43,6 +43,7 @@ class HttpModule(conf: HttpConf) extends AbstractModule {
     httpConfig.setSecureScheme("https")
     httpConfig.setSecurePort(conf.httpsPort())
     httpConfig.setOutputBufferSize(32768)
+    httpConfig.setSendServerVersion(false)
 
     def addConnector(name: String)(connector: Option[Connector]): Unit = {
       connector match {


### PR DESCRIPTION

This was marked as a potential security problem: https://jira.mesosphere.com/browse/DCOS-14534