### PR TITLE
Remove Marathon as a Chaos user

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,4 @@ The team at [Mesosphere](https://mesosphere.com/) is also happy to answer any qu
 
 ## Current Users
 
-* [Marathon](https://github.com/mesosphere/marathon), an Apache Mesos framework for long-running services.
 * [Chronos](https://github.com/mesos/chronos), a fault tolerant job scheduler that handles dependencies and ISO8601 based schedules.


### PR DESCRIPTION
Marathon has removed its dependency on Chaos long, long time ago.